### PR TITLE
태그, 카테고리 선택에 따라 필터링되도록 하는 로직 추가

### DIFF
--- a/src/components/TagList/index.tsx
+++ b/src/components/TagList/index.tsx
@@ -5,14 +5,30 @@ import { Typography } from "../common/Typography";
 
 const Wrapper = styled(Flex)``;
 
-export const TagList = ({ tags }: { tags: string[] }) => {
+export const TagList = ({
+  tags,
+  selectedTag,
+  onTagClick,
+}: {
+  tags: string[];
+  selectedTag: string | undefined;
+  onTagClick: (tag: string) => void;
+}) => {
   return (
     <Wrapper direction="column" gap={10}>
       <Typography variant="title6">🏷️ Tags</Typography>
 
       <Flex align="center" css={{ width: "100%", gap: "6px" }}>
         {tags.map((tag) => {
-          return <Tag key={tag}>{tag}</Tag>;
+          return (
+            <Tag
+              key={tag}
+              active={selectedTag === tag}
+              onClick={() => onTagClick(selectedTag === tag ? undefined : tag)}
+            >
+              {tag}
+            </Tag>
+          );
         })}
       </Flex>
     </Wrapper>

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,16 +1,25 @@
 import { Flex } from "./Flex";
 
-export const Tag = ({ children }: { children: React.ReactNode }) => {
+export const Tag = ({
+  onClick,
+  children,
+  active,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  active?: boolean;
+}) => {
   return (
-    <Flex
-      css={{
+    <button
+      style={{
         borderRadius: "50px",
-        backgroundColor: "rgb(232, 232, 232)",
+        backgroundColor: active ? "rgb(232, 232, 232)" : "rgb(255, 255, 255)",
         padding: "4px 8px",
         width: "fit-content",
       }}
+      onClick={onClick}
     >
       {children}
-    </Flex>
+    </button>
   );
 };


### PR DESCRIPTION
## 작업 내용
: 카테고리(탭), 태그 를 선택 한거에 따라 블로그 포스팅 글들이 필터링되도록 합니다.

## 스크린샷 (옵션) 