### PR TITLE
"/posts" 경로 제거

### DIFF
--- a/src/pages/[slug].tsx
+++ b/src/pages/[slug].tsx
@@ -17,7 +17,7 @@ export async function getStaticPaths() {
   const posts = await getPosts();
   const slugs = posts.map((post) => post.slug);
   return {
-    paths: slugs.map((slug) => `/posts/${slug}`),
+    paths: slugs.map((slug) => `/${slug}`),
     fallback: false,
   };
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <div>
-      <h1>Welcome to Next.js!</h1>
-    </div>
-  );
-}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -96,7 +96,7 @@ export default function PostsPage() {
           />
           {filteredPosts.length > 0 ? (
             filteredPosts.map((post) => (
-              <Link key={post.slug} href={`/posts/${post.slug}`}>
+              <Link key={post.slug} href={`/${post.slug}`}>
                 <PreviewContent post={post} />
               </Link>
             ))


### PR DESCRIPTION
## 작업 내용
'/posts' 경로를 제거하고 기존에 /posts경로 하위에서 렌더링되었던 페이지들을 '/'경로 기준으로 옮깁니다.


